### PR TITLE
feature/filterable properties via metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ tags
 singer-check-tap-data
 state.json
 .idea/
+.vscode/

--- a/catalog.json
+++ b/catalog.json
@@ -79,12 +79,26 @@
             ]
           },
           "invoices": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
               "array"
             ]
           },
           "refunds": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
               "array"
@@ -132,11 +146,1137 @@
       "stream": "credits",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "credit_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "credit_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "credit_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "credit_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "applied_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unapplied_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "reference_number"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_apply"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "gl_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoices"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "customers",
+      "key_properties": [
+        "company_id",
+        "customer_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
           },
-          "breadcrumb": []
+          "customer_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "customer_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "parent_customer": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "website": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_terms": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_cycle_day": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipping_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_batch": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tax_exempt": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "balance": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "auto_pay": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "edit_auto_pay": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "price_book_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "discounted_cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "delivery_preferences": {
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "customers",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "customer_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "parent_customer"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "website"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_terms"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_cycle_day"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "shipping_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_batch"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tax_exempt"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "balance"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_pay"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "edit_auto_pay"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "price_book_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discounted_cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "delivery_preferences"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "products",
+      "key_properties": [
+        "company_id",
+        "product_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sku": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "taxable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "price": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "income_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "deferred_revenue_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "revenue_rule_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "recognition_start_date": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "order_journal_entry_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "order_debit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "order_credit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "invoice_journal_entry_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "invoice_debit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "invoice_credit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "revenue_journal_entry_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "revenue_debit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "revenue_credit_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "products",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "product_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sku"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "taxable"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "income_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "deferred_revenue_enabled"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_rule_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "recognition_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_journal_entry_enabled"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_debit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_credit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_journal_entry_enabled"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_debit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_credit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_journal_entry_enabled"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_debit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_credit_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
@@ -376,12 +1516,26 @@
             ]
           },
           "tax_lines": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
               "array"
             ]
           },
           "applied_tiers": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
               "array"
@@ -435,11 +1589,876 @@
       "stream": "invoices",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "invoice_id",
+              "invoice_line_no"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_line_no"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_contact"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "shipping_contact"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "due_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_run_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subtotal"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_tax"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "paid_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "balance"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_terms"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_line_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "end_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unit_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "list_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "list_price_base"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "taxable"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "quantity"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "effective_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "line_tax"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tax_lines"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "applied_tiers"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "line_custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "revenue_schedules",
+      "key_properties": [
+        "company_id",
+        "revenue_schedule_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
           },
-          "breadcrumb": []
+          "revenue_schedule_id": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "source_transaction": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_timing": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "total_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "recognized_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "unrecognized_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "end_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "schedule_lines": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "revenue_schedules",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "revenue_schedule_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "source_transaction"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "total_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "recognized_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unrecognized_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "end_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "schedule_lines"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
@@ -591,77 +2610,277 @@
       "stream": "orders",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "order_id",
+              "order_line_no"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_line_no"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "separate_invoice"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unit_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "quantity"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "effective_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
     {
-      "tap_stream_id": "customers",
+      "tap_stream_id": "payments",
       "key_properties": [
         "company_id",
-        "customer_id"
+        "payment_id"
       ],
       "schema": {
         "properties": {
           "company_id": {
             "type": "string"
           },
+          "payment_id": {
+            "type": "string"
+          },
           "customer_id": {
             "type": "string"
           },
-          "name": {
+          "payment_date": {
+            "format": "date",
             "type": [
               "null",
               "string"
             ]
           },
-          "customer_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "parent_customer": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "website": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_terms": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_cycle_day": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_contact_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "shipping_contact_id": {
+          "notes": {
             "type": [
               "null",
               "string"
@@ -673,28 +2892,46 @@
               "string"
             ]
           },
-          "billing_batch": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "tax_exempt": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "balance": {
+          "payment_amount": {
             "type": [
               "null",
               "number"
             ]
           },
-          "auto_pay": {
+          "fee_amount": {
             "type": [
               "null",
-              "boolean"
+              "number"
+            ]
+          },
+          "applied_amount": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "unapplied_amount": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "refunded_amount": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "payment_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_method": {
+            "type": [
+              "null",
+              "string"
             ]
           },
           "currency": {
@@ -703,34 +2940,54 @@
               "string"
             ]
           },
-          "edit_auto_pay": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "price_book_id": {
+          "reference_number": {
             "type": [
               "null",
               "string"
             ]
           },
-          "cmrr": {
+          "auto_apply": {
             "type": [
               "null",
-              "number"
+              "boolean"
             ]
           },
-          "discounted_cmrr": {
+          "retried_attempts": {
             "type": [
               "null",
-              "number"
+              "integer"
             ]
           },
-          "delivery_preferences": {
+          "invoices": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
-              "object"
+              "array"
+            ]
+          },
+          "refunds": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "gl_account": {
+            "type": [
+              "null",
+              "string"
             ]
           },
           "created_by": {
@@ -772,124 +3029,338 @@
         ],
         "additionalProperties": false
       },
-      "stream": "customers",
+      "stream": "payments",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "payment_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "fee_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "applied_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unapplied_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunded_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_method"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "reference_number"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_apply"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "retried_attempts"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoices"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "gl_account"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
     {
-      "tap_stream_id": "revenue_schedules",
+      "tap_stream_id": "refunds",
       "key_properties": [
         "company_id",
-        "revenue_schedule_id"
+        "refund_id"
       ],
       "schema": {
         "properties": {
           "company_id": {
             "type": "string"
           },
-          "revenue_schedule_id": {
+          "refund_id": {
             "type": "string"
           },
           "customer_id": {
             "type": "string"
           },
-          "source_transaction": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "product_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "product_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "plan_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "plan_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_timing": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "total_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "recognized_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "unrecognized_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "start_date": {
+          "refund_date": {
             "format": "date",
             "type": [
               "null",
               "string"
             ]
           },
-          "end_date": {
-            "format": "date",
+          "refund_amount": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "refund_type": {
             "type": [
               "null",
               "string"
             ]
           },
-          "schedule_lines": {
+          "notes": {
             "type": [
               "null",
-              "array"
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "reference_number": {
+            "type": [
+              "null",
+              "string"
             ]
           },
           "created_by": {
@@ -917,6 +3388,12 @@
               "null",
               "string"
             ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
           }
         },
         "type": [
@@ -925,14 +3402,181 @@
         ],
         "additionalProperties": false
       },
-      "stream": "revenue_schedules",
+      "stream": "refunds",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "refund_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refund_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refund_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refund_amount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refund_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "reference_number"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
@@ -1045,6 +3689,13 @@
             ]
           },
           "schedule_lines": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
             "type": [
               "null",
               "array"
@@ -1086,11 +3737,248 @@
       "stream": "billing_schedules",
       "metadata": [
         {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "company_id",
+              "billing_schedule_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "end_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "monthly_recurring_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "annual_contract_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "total_contract_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "amount_invoiced"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "schedule_lines"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     },
@@ -1459,478 +4347,599 @@
       "stream": "subscriptions",
       "metadata": [
         {
+          "breadcrumb": [],
           "metadata": {
-            "inclusion": "automatic",
+            "table-key-properties": [
+              "company_id",
+              "subscription_id",
+              "subscription_line_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available",
             "selected": true
-          },
-          "breadcrumb": []
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "payments",
-      "key_properties": [
-        "company_id",
-        "payment_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": "string"
-          },
-          "payment_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "payment_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "notes": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "fee_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "applied_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "unapplied_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "refunded_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "payment_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_method": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "reference_number": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "auto_apply": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "retried_attempts": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "invoices": {
-            "type": [
-              "null",
-              "array"
-            ]
-          },
-          "refunds": {
-            "type": [
-              "null",
-              "array"
-            ]
-          },
-          "gl_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ]
           }
         },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "payments",
-      "metadata": [
         {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "products",
-      "key_properties": [
-        "company_id",
-        "product_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": "string"
-          },
-          "product_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "sku": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "taxable": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "price": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "income_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "deferred_revenue_enabled": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "revenue_rule_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "recognition_start_date": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "order_journal_entry_enabled": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "order_debit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "order_credit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "invoice_journal_entry_enabled": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "invoice_debit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "invoice_credit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "revenue_journal_entry_enabled": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "revenue_debit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "revenue_credit_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "selected-by-default": true
           }
         },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "products",
-      "metadata": [
         {
+          "breadcrumb": [
+            "properties",
+            "subscription_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "refunds",
-      "key_properties": [
-        "company_id",
-        "refund_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": "string"
-          },
-          "refund_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "refund_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "refund_amount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "refund_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "notes": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "reference_number": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "selected-by-default": true
           }
         },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "refunds",
-      "metadata": [
         {
+          "breadcrumb": [
+            "properties",
+            "subscription_line_id"
+          ],
           "metadata": {
             "inclusion": "automatic",
-            "selected": true
-          },
-          "breadcrumb": []
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "bill_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "shipping_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "service_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_placed_at"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "contract_effective_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cancellation_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_renew"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_terms"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discounted_cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "separate_invoice"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "version"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "version_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "contract_term"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "renewal_term"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tcv"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "pricing_model"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "list_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "price_base"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "quantity"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "included_units"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discount"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "effective_price"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_period"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unit_of_measure"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "current_period_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "current_period_end_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_period_start_alignment"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_day"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "prorate_partial_periods"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "backcharge_current_period"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "prepayment_periods"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "renewal_increment_percent"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "override_renewal_increment_percent"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_end_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected-by-default": true
+          }
         }
       ]
     }

--- a/ordway_tap/__init__.py
+++ b/ordway_tap/__init__.py
@@ -45,7 +45,7 @@ def discover():
     streams = []
     for stream_id, schema in raw_schemas.items():
         # TODO: populate any metadata and stream's key properties here..
-        stream_metadata = property.get_stream_metadata(schema)
+        stream_metadata = property.get_stream_metadata(stream_id, schema.to_dict())
         key_properties = property.get_key_properties(stream_id)
         streams.append(
             CatalogEntry(
@@ -83,7 +83,7 @@ def sync(config, state, catalog):
         current_time = datetime.utcnow().isoformat(sep='T', timespec='milliseconds')
         filter_datetime = state.get(stream.tap_stream_id, {}).get('last_synced', '1970-01-01T00:00:00.000')
         # Sync records via API
-        api_sync.sync(stream.tap_stream_id, filter_datetime)
+        api_sync.sync(stream, filter_datetime)
         state[stream.tap_stream_id] = {'synced': True, 'last_synced': current_time}
         singer.write_state(state)
 

--- a/ordway_tap/api_sync/__init__.py
+++ b/ordway_tap/api_sync/__init__.py
@@ -1,3 +1,6 @@
+from singer.transform import Transformer
+from singer.metadata import to_map as mdata_to_map
+from ordway_tap.api_sync.utils import print_record
 from ordway_tap.api_sync import invoice, subscription, customer, payment, credit, refund, billing_schedule,\
                                 revenue_schedule, product, order
 
@@ -14,6 +17,13 @@ sync_methods = {
     'orders': order.sync
 }
 
-
 def sync(stream, timestamp):
-    sync_methods[stream](timestamp)
+    with Transformer() as transformer:
+        for record in sync_methods[stream.tap_stream_id](timestamp):
+            transformed_record = transformer.transform(
+                record,
+                stream.schema.to_dict(),
+                metadata=mdata_to_map(stream.metadata)
+            )
+            
+            print_record(stream.tap_stream_id, transformed_record)

--- a/ordway_tap/api_sync/billing_schedule.py
+++ b/ordway_tap/api_sync/billing_schedule.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.billing_schedule import map_bs_response
 
 
 def sync(timestamp):
     for bs_response in get_index_data('/api/v1/billing_schedules', params={'updated_date>': timestamp}):
-        print_record('billing_schedules', map_bs_response(bs_response))
+        yield map_bs_response(bs_response)

--- a/ordway_tap/api_sync/credit.py
+++ b/ordway_tap/api_sync/credit.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.credit import map_credit_response
 
 
 def sync(timestamp):
     for credit_response in get_index_data('/api/v1/credits', params={'updated_date>': timestamp}):
-        print_record('credits', map_credit_response(credit_response))
+        yield map_credit_response(credit_response)

--- a/ordway_tap/api_sync/customer.py
+++ b/ordway_tap/api_sync/customer.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.customer import map_customer_response
 
 
 def sync(timestamp):
     for customer_response in get_index_data('/api/v1/customers', params={'updated_date>': timestamp}):
-        print_record('customers', map_customer_response(customer_response))
+        yield map_customer_response(customer_response)

--- a/ordway_tap/api_sync/invoice.py
+++ b/ordway_tap/api_sync/invoice.py
@@ -1,9 +1,8 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.invoice import map_invoice_response
 
 
 def sync(timestamp):
     for invoice_response in get_index_data('/api/v1/invoices', params={'updated_date>': timestamp}):
         for invoice in map_invoice_response(invoice_response):
-            print_record('invoices', invoice)
+            yield invoice

--- a/ordway_tap/api_sync/order.py
+++ b/ordway_tap/api_sync/order.py
@@ -1,9 +1,8 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.order import map_order_response
 
 
 def sync(timestamp):
     for order_response in get_index_data('/api/v1/orders', params={'updated_date>': timestamp}):
         for order_with_lines in map_order_response(order_response):
-            print_record('orders', order_with_lines)
+            yield order_with_lines

--- a/ordway_tap/api_sync/payment.py
+++ b/ordway_tap/api_sync/payment.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.payment import map_payment_response
 
 
 def sync(timestamp):
     for payment_response in get_index_data('/api/v1/payments', params={'updated_date>': timestamp}):
-        print_record('payments', map_payment_response(payment_response))
+        yield map_payment_response(payment_response)

--- a/ordway_tap/api_sync/product.py
+++ b/ordway_tap/api_sync/product.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.product import map_product_response
 
 
 def sync(timestamp):
     for product_response in get_index_data('/api/v1/products', params={'updated_date>': timestamp}):
-        print_record('products', map_product_response(product_response))
+        yield map_product_response(product_response)

--- a/ordway_tap/api_sync/refund.py
+++ b/ordway_tap/api_sync/refund.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.refund import map_refund_response
 
 
 def sync(timestamp):
     for refund_response in get_index_data('/api/v1/refunds', params={'updated_date>': timestamp}):
-        print_record('refunds', map_refund_response(refund_response))
+        yield map_refund_response(refund_response)

--- a/ordway_tap/api_sync/revenue_schedule.py
+++ b/ordway_tap/api_sync/revenue_schedule.py
@@ -1,8 +1,7 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.revenue_schedule import map_rs_response
 
 
 def sync(timestamp):
     for rs_response in get_index_data('/api/v1/revenue_schedules', params={'updated_date>': timestamp}):
-        print_record('revenue_schedules', map_rs_response(rs_response))
+        yield map_rs_response(rs_response)

--- a/ordway_tap/api_sync/subscription.py
+++ b/ordway_tap/api_sync/subscription.py
@@ -1,9 +1,8 @@
 from ordway_tap.api_sync.api import get_index_data
-from ordway_tap.api_sync.utils import print_record
 from ordway_tap.record.subscription import map_subscription_response
 
 
 def sync(timestamp):
     for subscription_response in get_index_data('/api/v1/subscriptions', params={'updated_date>': timestamp}):
         for subscription_with_plan in map_subscription_response(subscription_response):
-            print_record('subscriptions', subscription_with_plan)
+            yield subscription_with_plan

--- a/ordway_tap/schemas/billing_schedules.json
+++ b/ordway_tap/schemas/billing_schedules.json
@@ -1,7 +1,13 @@
 {
-	"type": ["null", "object"],
+	"type": [
+		"null",
+		"object"
+	],
 	"additionalProperties": false,
-	"required": ["company_id", "billing_schedule_id"],
+	"required": [
+		"company_id",
+		"billing_schedule_id"
+	],
 	"properties": {
 		"company_id": {
 			"type": "string"
@@ -13,66 +19,133 @@
 			"type": "string"
 		},
 		"customer_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"subscription_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_type": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_timing": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"start_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"end_date": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"monthly_recurring_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"annual_contract_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"total_contract_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"amount_invoiced": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"currency": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"schedule_lines": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"created_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"updated_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"updated_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		}
 	}

--- a/ordway_tap/schemas/credits.json
+++ b/ordway_tap/schemas/credits.json
@@ -1,7 +1,13 @@
 {
-	"type": ["null", "object"],
+	"type": [
+		"null",
+		"object"
+	],
 	"additionalProperties": false,
-	"required": ["company_id", "credit_id"],
+	"required": [
+		"company_id",
+		"credit_id"
+	],
 	"properties": {
 		"company_id": {
 			"type": "string"
@@ -13,58 +19,123 @@
 			"type": "string"
 		},
 		"credit_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"notes": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"status": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"credit_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"applied_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"unapplied_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"currency": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"reference_number": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"auto_apply": {
-			"type": ["null", "boolean"]
+			"type": [
+				"null",
+				"boolean"
+			]
 		},
 		"gl_account": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"invoices": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"refunds": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"created_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"updated_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"updated_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"custom_fields": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		}
 	}
 }

--- a/ordway_tap/schemas/invoices.json
+++ b/ordway_tap/schemas/invoices.json
@@ -1,7 +1,14 @@
 {
-	"type": ["null", "object"],
+	"type": [
+		"null",
+		"object"
+	],
 	"additionalProperties": false,
-	"required": ["company_id", "invoice_id", "invoice_line_no"],
+	"required": [
+		"company_id",
+		"invoice_id",
+		"invoice_line_no"
+	],
 	"properties": {
 		"company_id": {
 			"type": "string"
@@ -16,139 +23,282 @@
 			"type": "string"
 		},
 		"billing_contact": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		},
 		"shipping_contact": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		},
 		"customer_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"invoice_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"due_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"billing_run_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"subtotal": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"invoice_tax": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"invoice_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"paid_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"balance": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"status": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"notes": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"currency": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"payment_terms": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"subscription_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"plan_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"plan_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"subscription_line_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_type": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"description": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"start_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"end_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"unit_price": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"list_price": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"list_price_base": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"taxable": {
-			"type": ["null", "boolean"]
+			"type": [
+				"null",
+				"boolean"
+			]
 		},
 		"quantity": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"discount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"effective_price": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"line_tax": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"tax_lines": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"applied_tiers": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
-        "created_by": {
-			"type": ["null", "string"]
+		"created_by": {
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"updated_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"updated_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"custom_fields": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		},
 		"line_custom_fields": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		}
 	}
 }

--- a/ordway_tap/schemas/payments.json
+++ b/ordway_tap/schemas/payments.json
@@ -1,7 +1,13 @@
 {
-	"type": ["null", "object"],
+	"type": [
+		"null",
+		"object"
+	],
 	"additionalProperties": false,
-	"required": ["company_id", "payment_id"],
+	"required": [
+		"company_id",
+		"payment_id"
+	],
 	"properties": {
 		"company_id": {
 			"type": "string"
@@ -13,73 +19,153 @@
 			"type": "string"
 		},
 		"payment_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"notes": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"status": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"payment_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"fee_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"applied_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"unapplied_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"refunded_amount": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"payment_type": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"payment_method": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"currency": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"reference_number": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"auto_apply": {
-			"type": ["null", "boolean"]
+			"type": [
+				"null",
+				"boolean"
+			]
 		},
 		"retried_attempts": {
-			"type": ["null", "integer"]
+			"type": [
+				"null",
+				"integer"
+			]
 		},
 		"invoices": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"refunds": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"gl_account": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"updated_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"updated_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"custom_fields": {
-			"type": ["null", "object"]
+			"type": [
+				"null",
+				"object"
+			]
 		}
 	}
 }

--- a/ordway_tap/schemas/revenue_schedules.json
+++ b/ordway_tap/schemas/revenue_schedules.json
@@ -1,7 +1,13 @@
 {
-	"type": ["null", "object"],
+	"type": [
+		"null",
+		"object"
+	],
 	"additionalProperties": false,
-	"required": ["company_id", "revenue_schedule_id"],
+	"required": [
+		"company_id",
+		"revenue_schedule_id"
+	],
 	"properties": {
 		"company_id": {
 			"type": "string"
@@ -13,65 +19,128 @@
 			"type": "string"
 		},
 		"source_transaction": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"product_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"plan_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"plan_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
-
 		"charge_id": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_name": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_type": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"charge_timing": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"total_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"recognized_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"unrecognized_revenue": {
-			"type": ["null", "number"]
+			"type": [
+				"null",
+				"number"
+			]
 		},
 		"start_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"end_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date"
 		},
 		"schedule_lines": {
-			"type": ["null", "array"]
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"type": [
+					"null",
+					"object"
+				],
+				"additionalProperties": true
+			}
 		},
 		"created_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"updated_by": {
-			"type": ["null", "string"]
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"created_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		},
 		"updated_date": {
-			"type": ["null", "string"],
+			"type": [
+				"null",
+				"string"
+			],
 			"format": "date-time"
 		}
 	}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="ordway-tap",
-    version="0.1.0",
+    version="0.2.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
**Description:**
By using Singer's Transformer.transform, user's are able to decide which particular properties they want to replicate in a given stream via its metadata. For example:
```
{
          "breadcrumb": [
            "properties",
            "notes"
          ],
          "metadata": {
            "inclusion": "available",
            "selected-by-default": true,
            "selected": false
          }
},
```
will no longer emit the notes property on credits. 

Other benefits include:
- Raising an exception if the data  coming in doesn't match our schemas
- Performing basic transformations for us (see https://github.com/singer-io/singer-python/blob/master/singer/transform.py)

**Changes:**
- Process all synced records through Transformer.transform
- Generate metadata for all of a stream's properties

I haven't touched anything in the kafka_consumer module yet, as I wanted to be sure we're in agreement over this change beforehand. Naturally, tests need to be added, but everything appears to be working fine on my end.