### PR TITLE
Fix pagination

### DIFF
--- a/ordway_tap/api/base.py
+++ b/ordway_tap/api/base.py
@@ -166,7 +166,7 @@ class RequestHandler:
             for result in results:
                 yield result
 
-            if len(results) < self.page_size:
+            if len(results) == 0:
                 self._exhausted = True
             else:
                 default_params["page"] += 1


### PR DESCRIPTION
**Changes**:
* Fixed pagination

Checking whether the response contains fewer results than what is specified by the page size parameter does not guarantee we are on the last page. Instead, check whether the response contains no results.