### PR TITLE
Invoice.unit_price and Order.unit_price type string

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,629 +1,20 @@
 {
   "streams": [
     {
-      "tap_stream_id": "billing_runs",
+      "tap_stream_id": "customer_notes",
       "replication_method": "FULL_TABLE",
       "key_properties": [
-        "billing_run_id"
-      ],
-      "schema": {
-        "properties": {
-          "billing_run_id": {
-            "type": "string"
-          },
-          "company_id": {
-            "type": "string"
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "target_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "invoice_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "invoices_total": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "invoices_count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "filter_options": {
-            "properties": {},
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "billing_runs",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "billing_run_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_run_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "target_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "invoice_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "invoices_total"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "invoices_count"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "currency"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "filter_options"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "billing_schedules",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "billing_schedule_id"
+        "customer_note_id"
       ],
       "schema": {
         "properties": {
           "company_id": {
-            "type": "string"
-          },
-          "billing_schedule_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "customer_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "subscription_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "product_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "product_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_timing": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "start_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "end_date": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "monthly_recurring_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "annual_contract_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "total_contract_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "amount_invoiced": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "schedule_lines": {
-            "items": {
-              "type": [
-                "null",
-                "object"
-              ],
-              "additionalProperties": true
-            },
-            "type": [
-              "null",
-              "array"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "billing_schedules",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "billing_schedule_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_schedule_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "subscription_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "product_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "product_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_timing"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "start_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "end_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "monthly_recurring_revenue"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "annual_contract_revenue"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "total_contract_revenue"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "amount_invoiced"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "currency"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "schedule_lines"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "charges",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "charge_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": "string"
-          },
-          "charge_id": {
             "type": [
               "string"
             ]
           },
-          "product_id": {
+          "customer_note_id": {
             "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
               "string"
             ]
           },
@@ -633,164 +24,80 @@
               "string"
             ]
           },
-          "type": {
+          "title": {
+            "type": [
+              "string"
+            ]
+          },
+          "file_upload_file_name": {
             "type": [
               "null",
               "string"
             ]
           },
-          "timing": {
+          "file_upload_content_type": {
             "type": [
               "null",
               "string"
             ]
           },
-          "effective_date": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_date": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "pricing_model": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "list_price": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "charge_timing": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "list_price_base": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "billing_period": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_day": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_period_start_alignment": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "prorate_partial_periods": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "prepayment_periods": {
+          "file_upload_file_size": {
             "type": [
               "null",
               "integer"
             ]
           },
-          "prepayment_amount": {
+          "file_upload_updated_at": {
+            "format": "date-time",
             "type": [
               "null",
+              "string"
+            ]
+          },
+          "has_versions": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "user_id": {
+            "type": [
               "integer"
             ]
           },
-          "unit_of_measure": {
+          "customer_id": {
             "type": [
-              "null",
-              "string"
+              "integer"
             ]
-          },
-          "plan": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "included_units": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "unused_prepayment_units": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "tiers": {
-            "properties": {
-              "tier": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "starting_unit": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "ending_unit": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "price": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
           }
         },
-        "type": "object",
+        "type": [
+          "null",
+          "object"
+        ],
         "additionalProperties": false
       },
-      "stream": "charges",
+      "stream": "customer_notes",
       "metadata": [
         {
           "breadcrumb": [],
           "metadata": {
             "table-key-properties": [
-              "charge_id"
+              "customer_note_id"
             ],
             "valid-replication-keys": [],
             "inclusion": "available"
@@ -808,28 +115,10 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_id"
+            "customer_note_id"
           ],
           "metadata": {
             "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "product_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "name"
-          ],
-          "metadata": {
-            "inclusion": "available"
           }
         },
         {
@@ -844,7 +133,7 @@
         {
           "breadcrumb": [
             "properties",
-            "type"
+            "title"
           ],
           "metadata": {
             "inclusion": "available"
@@ -853,7 +142,7 @@
         {
           "breadcrumb": [
             "properties",
-            "timing"
+            "file_upload_file_name"
           ],
           "metadata": {
             "inclusion": "available"
@@ -862,7 +151,7 @@
         {
           "breadcrumb": [
             "properties",
-            "effective_date"
+            "file_upload_content_type"
           ],
           "metadata": {
             "inclusion": "available"
@@ -871,7 +160,7 @@
         {
           "breadcrumb": [
             "properties",
-            "billing_date"
+            "file_upload_file_size"
           ],
           "metadata": {
             "inclusion": "available"
@@ -880,7 +169,7 @@
         {
           "breadcrumb": [
             "properties",
-            "pricing_model"
+            "file_upload_updated_at"
           ],
           "metadata": {
             "inclusion": "available"
@@ -889,7 +178,7 @@
         {
           "breadcrumb": [
             "properties",
-            "list_price"
+            "has_versions"
           ],
           "metadata": {
             "inclusion": "available"
@@ -898,7 +187,7 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_timing"
+            "created_at"
           ],
           "metadata": {
             "inclusion": "available"
@@ -907,7 +196,7 @@
         {
           "breadcrumb": [
             "properties",
-            "list_price_base"
+            "updated_at"
           ],
           "metadata": {
             "inclusion": "available"
@@ -916,492 +205,7 @@
         {
           "breadcrumb": [
             "properties",
-            "billing_period"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_day"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_period_start_alignment"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "prorate_partial_periods"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "prepayment_periods"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "prepayment_amount"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "unit_of_measure"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "plan"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "included_units"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "unused_prepayment_units"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "tiers"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "chart_of_accounts",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "code"
-      ],
-      "schema": {
-        "properties": {
-          "code": {
-            "type": [
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "account_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "sub_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "parent_account": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "format": "email",
-            "type": [
-              "string"
-            ]
-          },
-          "updated_by": {
-            "format": "email",
-            "type": [
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "stream": "chart_of_accounts",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "code"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "code"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "account_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "sub_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "parent_account"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "description"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "custom_fields"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "contacts",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "contact_id"
-      ],
-      "schema": {
-        "properties": {
-          "contact_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "company_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "customer_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "display_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "first_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "email": {
-            "format": "email",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "phone": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "mobile": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "job_title": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "department": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "notes": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "address1": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "address2": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "city": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "county": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "state": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "zip": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "country": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "format": "email",
-            "type": [
-              "string"
-            ]
-          },
-          "updated_by": {
-            "format": "email",
-            "type": [
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "stream": "contacts",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "contact_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "contact_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
+            "user_id"
           ],
           "metadata": {
             "inclusion": "available"
@@ -1411,195 +215,6 @@
           "breadcrumb": [
             "properties",
             "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "display_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "first_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "last_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "email"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "phone"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "mobile"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "job_title"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "department"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "notes"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "address1"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "address2"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "city"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "county"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "state"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "zip"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "country"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "custom_fields"
           ],
           "metadata": {
             "inclusion": "available"
@@ -1904,6 +519,128 @@
           "breadcrumb": [
             "properties",
             "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "webhooks",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "name"
+      ],
+      "schema": {
+        "properties": {
+          "name": {
+            "type": [
+              "string"
+            ]
+          },
+          "company_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "url": {
+            "format": "uri",
+            "type": [
+              "string"
+            ]
+          },
+          "events": {
+            "properties": {},
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "headers": {
+            "items": {
+              "properties": {
+                "key": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "stream": "webhooks",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "name"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "events"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "headers"
           ],
           "metadata": {
             "inclusion": "available"
@@ -2252,707 +989,6 @@
       ]
     },
     {
-      "tap_stream_id": "customers",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "customer_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "parent_customer": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "website": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_terms": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_cycle_day": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_contact_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "shipping_contact_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_batch": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "tax_exempt": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "balance": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "auto_pay": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "edit_auto_pay": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "price_book_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "cmrr": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "discounted_cmrr": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "delivery_preferences": {
-            "properties": {
-              "print": {
-                "type": [
-                  "boolean"
-                ]
-              },
-              "email": {
-                "type": [
-                  "boolean"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          },
-          "pay_now_url": {
-            "format": "uri",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "update_payment_method_url": {
-            "format": "uri",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "open_invoices_url": {
-            "format": "uri",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "customers",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "customer_id"
-            ],
-            "valid-replication-keys": [
-              "updated_date"
-            ],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "description"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "parent_customer"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "website"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_terms"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_cycle_day"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_contact_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "shipping_contact_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_batch"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "tax_exempt"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "balance"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "auto_pay"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "currency"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "edit_auto_pay"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "price_book_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "cmrr"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "discounted_cmrr"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "delivery_preferences"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "custom_fields"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "pay_now_url"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "update_payment_method_url"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "open_invoices_url"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "customer_notes",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "customer_note_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "customer_note_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "title": {
-            "type": [
-              "string"
-            ]
-          },
-          "file_upload_file_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "file_upload_content_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "file_upload_file_size": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "file_upload_updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "has_versions": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "user_id": {
-            "type": [
-              "integer"
-            ]
-          },
-          "customer_id": {
-            "type": [
-              "integer"
-            ]
-          }
-        },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "customer_notes",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "customer_note_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_note_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "description"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "title"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "file_upload_file_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "file_upload_content_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "file_upload_file_size"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "file_upload_updated_at"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "has_versions"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_at"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_at"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "user_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
       "tap_stream_id": "invoices",
       "replication_key": "updated_date",
       "replication_method": "INCREMENTAL",
@@ -3142,7 +1178,7 @@
           "unit_price": {
             "type": [
               "null",
-              "number"
+              "string"
             ]
           },
           "list_price": {
@@ -3798,7 +1834,7 @@
           "unit_price": {
             "type": [
               "null",
-              "number"
+              "string"
             ]
           },
           "quantity": {
@@ -4074,6 +2110,2937 @@
           "breadcrumb": [
             "properties",
             "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "customers",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "customer_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "parent_customer": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "website": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_terms": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_cycle_day": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipping_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_batch": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tax_exempt": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "balance": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "auto_pay": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "edit_auto_pay": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "price_book_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "discounted_cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "delivery_preferences": {
+            "properties": {
+              "print": {
+                "type": [
+                  "boolean"
+                ]
+              },
+              "email": {
+                "type": [
+                  "boolean"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "pay_now_url": {
+            "format": "uri",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "update_payment_method_url": {
+            "format": "uri",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "open_invoices_url": {
+            "format": "uri",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "customers",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "customer_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "parent_customer"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "website"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_terms"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_cycle_day"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "shipping_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_batch"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tax_exempt"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "balance"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_pay"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "edit_auto_pay"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "price_book_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discounted_cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "delivery_preferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "pay_now_url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "update_payment_method_url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "open_invoices_url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "payment_runs",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "payment_run_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "payment_run_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "target_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "success_count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "failure_count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payments_total_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "payments_success_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "payments_failed_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "refunds_total_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "refunds_success_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "refunds_failed_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "filter_options": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "target_invoice_due_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_per_customer": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "refunds_for_negative_invoices": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "send_email_on_payments_success": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "send_email_on_payment_fail": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "stream": "payment_runs",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "payment_run_id"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_run_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "target_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "success_count"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "failure_count"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payments_total_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payments_success_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payments_failed_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds_total_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds_success_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds_failed_value"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "filter_options"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "target_invoice_due_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_per_customer"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "refunds_for_negative_invoices"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "send_email_on_payments_success"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "send_email_on_payment_fail"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "billing_runs",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "billing_run_id"
+      ],
+      "schema": {
+        "properties": {
+          "billing_run_id": {
+            "type": "string"
+          },
+          "company_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "target_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "invoice_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "invoices_total": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "invoices_count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "filter_options": {
+            "properties": {},
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "billing_runs",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "billing_run_id"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_run_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "target_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoice_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoices_total"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "invoices_count"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "filter_options"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "payment_methods",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "payment_method_id"
+      ],
+      "schema": {
+        "properties": {
+          "payment_method_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "company_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "customer_id": {
+            "type": [
+              "string"
+            ]
+          },
+          "customer_payment_gateway_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_type": {
+            "type": [
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "account_number": {
+            "type": [
+              "string"
+            ]
+          },
+          "routing_number": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "account_holder_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "account_holder_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "expiry": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "default": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "cvc": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "stream": "payment_methods",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "payment_method_id"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_method_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_payment_gateway_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "account_number"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "routing_number"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "account_holder_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "account_holder_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "country"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "expiry"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "default"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cvc"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "revenue_schedules",
+      "replication_key": "updated_date",
+      "replication_method": "INCREMENTAL",
+      "key_properties": [
+        "revenue_schedule_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
+          },
+          "revenue_schedule_id": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "source_transaction": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_timing": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "total_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "recognized_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "unrecognized_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "end_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "schedule_lines": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "revenue_schedules",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "revenue_schedule_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "source_transaction"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "total_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "recognized_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unrecognized_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "start_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "end_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "schedule_lines"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "billing_schedules",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "billing_schedule_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
+          },
+          "billing_schedule_id": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "customer_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "subscription_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_timing": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "end_date": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "monthly_recurring_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "annual_contract_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "total_contract_revenue": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "amount_invoiced": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "schedule_lines": {
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "billing_schedules",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "billing_schedule_id"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "start_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "end_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "monthly_recurring_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "annual_contract_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "total_contract_revenue"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "amount_invoiced"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "schedule_lines"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "subscriptions",
+      "replication_key": "updated_date",
+      "replication_method": "INCREMENTAL",
+      "key_properties": [
+        "subscription_id"
+      ],
+      "schema": {
+        "properties": {
+          "company_id": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "type": "string"
+          },
+          "subscription_line_id": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "bill_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipping_contact_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "service_start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "order_placed_at": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "contract_effective_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cancellation_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "auto_renew": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "currency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "payment_terms": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "discounted_cmrr": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "separate_invoice": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "notes": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "version": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "version_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "contract_term": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "renewal_term": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tcv": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "product_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "product_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "pricing_model": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "list_price": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "price_base": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "quantity": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "included_units": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "discount": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "effective_price": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "charge_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_period": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "unit_of_measure": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "current_period_start_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "current_period_end_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_schedule_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "revenue_schedule_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "charge_timing": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_period_start_alignment": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "billing_day": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "prorate_partial_periods": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "backcharge_current_period": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "prepayment_periods": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "renewal_increment_percent": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "override_renewal_increment_percent": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "charge_end_date": {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_by": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "charge_custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "subscriptions",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "subscription_id"
+            ],
+            "valid-replication-keys": [
+              "updated_date"
+            ],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "company_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "subscription_line_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "customer_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "bill_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "shipping_contact_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "service_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "order_placed_at"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "contract_effective_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cancellation_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "auto_renew"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "currency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "payment_terms"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discounted_cmrr"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "separate_invoice"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "version"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "version_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "contract_term"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "renewal_term"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tcv"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "product_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "plan_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "pricing_model"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "list_price"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "price_base"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "quantity"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "included_units"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "discount"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "effective_price"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_period"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unit_of_measure"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "current_period_start_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "current_period_end_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "revenue_schedule_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_timing"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_period_start_alignment"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "billing_day"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "prorate_partial_periods"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "backcharge_current_period"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "prepayment_periods"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "renewal_increment_percent"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "override_renewal_increment_percent"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_end_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "charge_custom_fields"
           ],
           "metadata": {
             "inclusion": "available"
@@ -4480,788 +5447,6 @@
           "breadcrumb": [
             "properties",
             "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "custom_fields"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "payment_methods",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "payment_method_id"
-      ],
-      "schema": {
-        "properties": {
-          "payment_method_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "company_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "customer_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "customer_payment_gateway_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_type": {
-            "type": [
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "account_number": {
-            "type": [
-              "string"
-            ]
-          },
-          "routing_number": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "account_holder_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "account_holder_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "country": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "expiry": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "default": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "cvc": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "stream": "payment_methods",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "payment_method_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_method_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_payment_gateway_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "account_number"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "routing_number"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "account_holder_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "account_holder_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "country"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "expiry"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "default"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "cvc"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "payment_runs",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "payment_run_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "payment_run_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "target_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "success_count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "failure_count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payments_total_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "payments_success_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "payments_failed_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "refunds_total_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "refunds_success_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "refunds_failed_value": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "filter_options": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          },
-          "target_invoice_due_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_per_customer": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "refunds_for_negative_invoices": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "send_email_on_payments_success": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "send_email_on_payment_fail": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "stream": "payment_runs",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "payment_run_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_run_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "target_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "success_count"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "failure_count"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "currency"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payments_total_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payments_success_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payments_failed_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "refunds_total_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "refunds_success_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "refunds_failed_value"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "filter_options"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "target_invoice_due_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_per_customer"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "refunds_for_negative_invoices"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "send_email_on_payments_success"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "send_email_on_payment_fail"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        }
-      ]
-    },
-    {
-      "tap_stream_id": "plans",
-      "replication_method": "FULL_TABLE",
-      "key_properties": [
-        "plan_id"
-      ],
-      "schema": {
-        "properties": {
-          "company_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "plan_id": {
-            "type": [
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "public_url": {
-            "format": "uri",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "stream": "plans",
-      "metadata": [
-        {
-          "breadcrumb": [],
-          "metadata": {
-            "table-key-properties": [
-              "plan_id"
-            ],
-            "valid-replication-keys": [],
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "company_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "plan_id"
-          ],
-          "metadata": {
-            "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "description"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_by"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "created_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "updated_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "public_url"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6226,26 +6411,18 @@
       ]
     },
     {
-      "tap_stream_id": "revenue_schedules",
-      "replication_key": "updated_date",
-      "replication_method": "INCREMENTAL",
+      "tap_stream_id": "charges",
+      "replication_method": "FULL_TABLE",
       "key_properties": [
-        "revenue_schedule_id"
+        "charge_id"
       ],
       "schema": {
         "properties": {
           "company_id": {
             "type": "string"
           },
-          "revenue_schedule_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "source_transaction": {
+          "charge_id": {
             "type": [
-              "null",
               "string"
             ]
           },
@@ -6255,40 +6432,52 @@
               "string"
             ]
           },
-          "product_name": {
+          "name": {
             "type": [
               "null",
               "string"
             ]
           },
-          "plan_id": {
+          "description": {
             "type": [
               "null",
               "string"
             ]
           },
-          "plan_name": {
+          "type": {
             "type": [
               "null",
               "string"
             ]
           },
-          "charge_id": {
+          "timing": {
             "type": [
               "null",
               "string"
             ]
           },
-          "charge_name": {
+          "effective_date": {
             "type": [
               "null",
               "string"
             ]
           },
-          "charge_type": {
+          "billing_date": {
             "type": [
               "null",
               "string"
+            ]
+          },
+          "pricing_model": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "list_price": {
+            "type": [
+              "null",
+              "number"
             ]
           },
           "charge_timing": {
@@ -6297,95 +6486,124 @@
               "string"
             ]
           },
-          "total_revenue": {
+          "list_price_base": {
             "type": [
               "null",
               "number"
             ]
           },
-          "recognized_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "unrecognized_revenue": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "start_date": {
-            "format": "date",
+          "billing_period": {
             "type": [
               "null",
               "string"
             ]
           },
-          "end_date": {
-            "format": "date",
+          "billing_day": {
             "type": [
               "null",
               "string"
             ]
           },
-          "schedule_lines": {
-            "items": {
-              "type": [
-                "null",
-                "object"
-              ],
-              "additionalProperties": true
+          "billing_period_start_alignment": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "prorate_partial_periods": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "prepayment_periods": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "prepayment_amount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_of_measure": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "included_units": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "unused_prepayment_units": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tiers": {
+            "properties": {
+              "tier": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "starting_unit": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "ending_unit": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "price": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             },
             "type": [
               "null",
-              "array"
-            ]
-          },
-          "created_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_by": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_date": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
+              "object"
+            ],
+            "additionalProperties": false
           }
         },
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": "object",
         "additionalProperties": false
       },
-      "stream": "revenue_schedules",
+      "stream": "charges",
       "metadata": [
         {
           "breadcrumb": [],
           "metadata": {
             "table-key-properties": [
-              "revenue_schedule_id"
+              "charge_id"
             ],
-            "valid-replication-keys": [
-              "updated_date"
-            ],
+            "valid-replication-keys": [],
             "inclusion": "available"
           }
         },
@@ -6401,28 +6619,10 @@
         {
           "breadcrumb": [
             "properties",
-            "revenue_schedule_id"
+            "charge_id"
           ],
           "metadata": {
             "inclusion": "automatic"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "source_transaction"
-          ],
-          "metadata": {
-            "inclusion": "available"
           }
         },
         {
@@ -6437,7 +6637,7 @@
         {
           "breadcrumb": [
             "properties",
-            "product_name"
+            "name"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6446,7 +6646,7 @@
         {
           "breadcrumb": [
             "properties",
-            "plan_id"
+            "description"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6455,7 +6655,7 @@
         {
           "breadcrumb": [
             "properties",
-            "plan_name"
+            "type"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6464,7 +6664,7 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_id"
+            "timing"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6473,7 +6673,7 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_name"
+            "effective_date"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6482,7 +6682,25 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_type"
+            "billing_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "pricing_model"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "list_price"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6500,7 +6718,7 @@
         {
           "breadcrumb": [
             "properties",
-            "total_revenue"
+            "list_price_base"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6509,7 +6727,7 @@
         {
           "breadcrumb": [
             "properties",
-            "recognized_revenue"
+            "billing_period"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6518,7 +6736,7 @@
         {
           "breadcrumb": [
             "properties",
-            "unrecognized_revenue"
+            "billing_day"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6527,7 +6745,7 @@
         {
           "breadcrumb": [
             "properties",
-            "start_date"
+            "billing_period_start_alignment"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6536,7 +6754,7 @@
         {
           "breadcrumb": [
             "properties",
-            "end_date"
+            "prorate_partial_periods"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6545,7 +6763,7 @@
         {
           "breadcrumb": [
             "properties",
-            "schedule_lines"
+            "prepayment_periods"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6554,7 +6772,7 @@
         {
           "breadcrumb": [
             "properties",
-            "created_by"
+            "prepayment_amount"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6563,7 +6781,7 @@
         {
           "breadcrumb": [
             "properties",
-            "updated_by"
+            "unit_of_measure"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6572,7 +6790,7 @@
         {
           "breadcrumb": [
             "properties",
-            "created_date"
+            "plan"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6581,7 +6799,25 @@
         {
           "breadcrumb": [
             "properties",
-            "updated_date"
+            "included_units"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "unused_prepayment_units"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tiers"
           ],
           "metadata": {
             "inclusion": "available"
@@ -6796,317 +7032,30 @@
       ]
     },
     {
-      "tap_stream_id": "subscriptions",
-      "replication_key": "updated_date",
-      "replication_method": "INCREMENTAL",
+      "tap_stream_id": "plans",
+      "replication_method": "FULL_TABLE",
       "key_properties": [
-        "subscription_id"
+        "plan_id"
       ],
       "schema": {
         "properties": {
           "company_id": {
-            "type": "string"
+            "type": [
+              "string"
+            ]
           },
-          "subscription_id": {
-            "type": "string"
+          "plan_id": {
+            "type": [
+              "string"
+            ]
           },
-          "subscription_line_id": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "bill_contact_id": {
+          "name": {
             "type": [
               "null",
               "string"
             ]
           },
-          "shipping_contact_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_start_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "service_start_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "order_placed_at": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "contract_effective_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "cancellation_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "auto_renew": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "currency": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "payment_terms": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "cmrr": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "discounted_cmrr": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "separate_invoice": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "notes": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "version": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "version_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "contract_term": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "renewal_term": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "tcv": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "product_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "product_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "plan_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "pricing_model": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "list_price": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "price_base": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "quantity": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "included_units": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "discount": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "effective_price": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "charge_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_period": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "unit_of_measure": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "current_period_start_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "current_period_end_date": {
-            "format": "date",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_schedule_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "revenue_schedule_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "charge_timing": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_period_start_alignment": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "billing_day": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "prorate_partial_periods": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "backcharge_current_period": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "prepayment_periods": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "renewal_increment_percent": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "override_renewal_increment_percent": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "charge_end_date": {
-            "format": "date",
+          "description": {
             "type": [
               "null",
               "string"
@@ -7138,36 +7087,39 @@
               "string"
             ]
           },
+          "public_url": {
+            "format": "uri",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "custom_fields": {
             "type": [
               "null",
               "object"
-            ]
-          },
-          "charge_custom_fields": {
-            "type": [
-              "null",
-              "object"
-            ]
+            ],
+            "additionalProperties": true
           }
         },
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": "object",
         "additionalProperties": false
       },
-      "stream": "subscriptions",
+      "stream": "plans",
       "metadata": [
         {
           "breadcrumb": [],
           "metadata": {
             "table-key-properties": [
-              "subscription_id"
+              "plan_id"
             ],
-            "valid-replication-keys": [
-              "updated_date"
-            ],
+            "valid-replication-keys": [],
             "inclusion": "available"
           }
         },
@@ -7183,7 +7135,7 @@
         {
           "breadcrumb": [
             "properties",
-            "subscription_id"
+            "plan_id"
           ],
           "metadata": {
             "inclusion": "automatic"
@@ -7192,7 +7144,7 @@
         {
           "breadcrumb": [
             "properties",
-            "subscription_line_id"
+            "name"
           ],
           "metadata": {
             "inclusion": "available"
@@ -7201,439 +7153,7 @@
         {
           "breadcrumb": [
             "properties",
-            "customer_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "bill_contact_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "shipping_contact_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "status"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_start_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "service_start_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "order_placed_at"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "contract_effective_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "cancellation_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "auto_renew"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "currency"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "payment_terms"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "cmrr"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "discounted_cmrr"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "separate_invoice"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "notes"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "version"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "version_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "contract_term"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "renewal_term"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "tcv"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "product_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "product_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "plan_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_name"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "pricing_model"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "list_price"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "price_base"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "quantity"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "included_units"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "discount"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "effective_price"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_type"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_period"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "unit_of_measure"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "current_period_start_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "current_period_end_date"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_schedule_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "revenue_schedule_id"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_timing"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_period_start_alignment"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "billing_day"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "prorate_partial_periods"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "backcharge_current_period"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "prepayment_periods"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "renewal_increment_percent"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "override_renewal_increment_percent"
-          ],
-          "metadata": {
-            "inclusion": "available"
-          }
-        },
-        {
-          "breadcrumb": [
-            "properties",
-            "charge_end_date"
+            "description"
           ],
           "metadata": {
             "inclusion": "available"
@@ -7678,7 +7198,7 @@
         {
           "breadcrumb": [
             "properties",
-            "custom_fields"
+            "public_url"
           ],
           "metadata": {
             "inclusion": "available"
@@ -7687,7 +7207,16 @@
         {
           "breadcrumb": [
             "properties",
-            "charge_custom_fields"
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
           ],
           "metadata": {
             "inclusion": "available"
@@ -7982,14 +7511,14 @@
       ]
     },
     {
-      "tap_stream_id": "webhooks",
+      "tap_stream_id": "contacts",
       "replication_method": "FULL_TABLE",
       "key_properties": [
-        "name"
+        "contact_id"
       ],
       "schema": {
         "properties": {
-          "name": {
+          "contact_id": {
             "type": [
               "string"
             ]
@@ -7999,58 +7528,152 @@
               "string"
             ]
           },
-          "url": {
-            "format": "uri",
+          "customer_id": {
             "type": [
               "string"
             ]
           },
-          "events": {
-            "properties": {},
+          "display_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "first_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "format": "email",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "mobile": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "job_title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "department": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "notes": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address1": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address2": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "city": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "county": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "zip": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_by": {
+            "format": "email",
+            "type": [
+              "string"
+            ]
+          },
+          "updated_by": {
+            "format": "email",
+            "type": [
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
             "type": [
               "null",
               "object"
             ],
             "additionalProperties": true
-          },
-          "headers": {
-            "items": {
-              "properties": {
-                "key": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              },
-              "type": [
-                "null",
-                "object"
-              ],
-              "additionalProperties": false
-            },
-            "type": [
-              "null",
-              "array"
-            ]
           }
         },
         "type": "object",
         "additionalProperties": false
       },
-      "stream": "webhooks",
+      "stream": "contacts",
       "metadata": [
         {
           "breadcrumb": [],
           "metadata": {
             "table-key-properties": [
-              "name"
+              "contact_id"
             ],
             "valid-replication-keys": [],
             "inclusion": "available"
@@ -8059,7 +7682,7 @@
         {
           "breadcrumb": [
             "properties",
-            "name"
+            "contact_id"
           ],
           "metadata": {
             "inclusion": "automatic"
@@ -8077,7 +7700,7 @@
         {
           "breadcrumb": [
             "properties",
-            "url"
+            "customer_id"
           ],
           "metadata": {
             "inclusion": "available"
@@ -8086,7 +7709,7 @@
         {
           "breadcrumb": [
             "properties",
-            "events"
+            "display_name"
           ],
           "metadata": {
             "inclusion": "available"
@@ -8095,7 +7718,384 @@
         {
           "breadcrumb": [
             "properties",
-            "headers"
+            "first_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "last_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "email"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "phone"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "mobile"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "job_title"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "department"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "notes"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "address1"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "address2"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "city"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "county"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "state"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "zip"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "country"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "chart_of_accounts",
+      "replication_method": "FULL_TABLE",
+      "key_properties": [
+        "code"
+      ],
+      "schema": {
+        "properties": {
+          "code": {
+            "type": [
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "account_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "sub_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "parent_account": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_by": {
+            "format": "email",
+            "type": [
+              "string"
+            ]
+          },
+          "updated_by": {
+            "format": "email",
+            "type": [
+              "string"
+            ]
+          },
+          "created_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_date": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_fields": {
+            "type": [
+              "null",
+              "object"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "stream": "chart_of_accounts",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "code"
+            ],
+            "valid-replication-keys": [],
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "code"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "account_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sub_type"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "parent_account"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "description"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_by"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "updated_date"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "custom_fields"
           ],
           "metadata": {
             "inclusion": "available"

--- a/ordway_tap/schemas/invoices.json
+++ b/ordway_tap/schemas/invoices.json
@@ -191,7 +191,7 @@
 		"unit_price": {
 			"type": [
 				"null",
-				"number"
+				"string"
 			]
 		},
 		"list_price": {

--- a/ordway_tap/schemas/orders.json
+++ b/ordway_tap/schemas/orders.json
@@ -47,7 +47,7 @@
 			"type": ["null", "string"]
 		},
 		"unit_price": {
-			"type": ["null", "number"]
+			"type": ["null", "string"]
 		},
 		"quantity": {
 			"type": ["null", "number"]


### PR DESCRIPTION
**Changes**:
* Changed the types of Invoice.unit_price and Order.unit_price to string.

It's typically a number, but I've had "flat fee" come through. If its only possible string value is "flat fee", it may be worthwhile to add a new bool property "flat_fee" that's set to true if `unit_price` is "flat fee". `unit_price` could then be set to None, so targets don't have to deal with two possible data types.